### PR TITLE
Add PHP 8.5 support and documentation publishing script

### DIFF
--- a/.github/workflows/backwards_compatibility.yml
+++ b/.github/workflows/backwards_compatibility.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: ${{ github.event.pull_request.base.ref != 'main' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set safe directory

--- a/.github/workflows/composer_require_checker.yml
+++ b/.github/workflows/composer_require_checker.yml
@@ -14,7 +14,7 @@ jobs:
         php-version: [ "8.5", "8.4", "8.3", "8.2", "8.1" ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set safe directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         php-version: [ "8.5", "8.4", "8.3", "8.2", "8.1"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Create .env
         run: touch .env

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 - [Requirements](#requirements)
     - [Getting an OMDb API Key](#getting-an-omdb-api-key)
 - [Installation](#installation)
+- [Documentation Publishing](#documentation-publishing)
+    - [Automatic Documentation Publishing](#automatic-documentation-publishing)
 - [Usage](#usage)
     - [poster()](#poster)
     - [byIdOrTitle()](#byidortitle)
@@ -72,7 +74,40 @@ Install `Zerotoprod\Omdb` via [Composer](https://getcomposer.org/):
 composer require zero-to-prod/omdb
 ```
 
-This will add the package to your project’s dependencies and create an autoloader entry for it.
+This will add the package to your project's dependencies and create an autoloader entry for it.
+
+## Documentation Publishing
+
+You can publish this README to your local documentation directory.
+
+This can be useful for providing documentation for AI agents.
+
+This can be done using the included script:
+
+```bash
+# Publish to default location (./docs/zero-to-prod/omdb)
+vendor/bin/zero-to-prod-omdb
+
+# Publish to custom directory
+vendor/bin/zero-to-prod-omdb /path/to/your/docs
+```
+
+### Automatic Documentation Publishing
+
+You can automatically publish documentation by adding the following to your `composer.json`:
+
+```json
+{
+    "scripts": {
+        "post-install-cmd": [
+            "zero-to-prod-omdb"
+        ],
+        "post-update-cmd": [
+            "zero-to-prod-omdb"
+        ]
+    }
+}
+```
 
 ## Usage
 

--- a/bin/zero-to-prod-omdb
+++ b/bin/zero-to-prod-omdb
@@ -1,0 +1,32 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Zero-to-Prod OMDb Documentation Publisher
+ *
+ * Publishes the README.md file to the user's documentation directory.
+ */
+
+require getcwd().'/vendor/autoload.php';
+
+use Zerotoprod\PackageHelper\PackageHelper;
+
+$target_path = getcwd().'/docs/zero-to-prod/omdb/';
+if (isset($argv[1])) {
+    $target_path = rtrim($argv[1], '/').'/';
+}
+
+$source_file = __DIR__.'/../README.md';
+
+if (!file_exists($source_file)) {
+    fwrite(STDERR, "Error: Not found $source_file\n");
+    exit(1);
+}
+
+try {
+    PackageHelper::copy($source_file, $target_path);
+    exit(0);
+} catch (RuntimeException $e) {
+    fwrite(STDERR, "Error: ".$e->getMessage()."\n");
+    exit(1);
+}

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,10 @@
     "zero-to-prod/omdb-api": "^1.0.1",
     "zero-to-prod/omdb-models": "^1.0",
     "ext-curl": "*",
-    "zero-to-prod/package-helper": "^1.1.3"
+    "zero-to-prod/package-helper": "^1.1.3",
+    "zero-to-prod/data-model": "^81.12",
+    "zero-to-prod/transformable": "^71.1",
+    "zero-to-prod/data-model-helper": "^81.11"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -55,5 +55,8 @@
   "suggest": {
     "zero-to-prod/data-model": "Transform Data to Type-Safe DTOs",
     "zero-to-prod/data-model-helper": "Helpers for a DataModel."
-  }
+  },
+  "bin": [
+    "bin/zero-to-prod-omdb"
+  ]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,3 +106,30 @@ services:
       - ./.vendor/php8.4:/app/vendor
     build:
       target: composer
+
+  php8.5:
+    volumes:
+      - ./:/app:delegated
+      - ./.vendor/php8.5:/app/vendor
+    build:
+      context: ./docker/8.5
+      target: base
+
+  debug8.5:
+    extends:
+      service: php8.5
+    volumes:
+      - ./:/app:delegated
+      - ./docker/8.5:/usr/local/etc/php
+      - ./.vendor/php8.5:/app/vendor
+    build:
+      target: debug
+
+  composer8.5:
+    extends:
+      service: php8.5
+    volumes:
+      - ./:/app:delegated
+      - ./.vendor/php8.5:/app/vendor
+    build:
+      target: composer

--- a/docker/8.5/.gitignore
+++ b/docker/8.5/.gitignore
@@ -1,0 +1,1 @@
+.phpunit.result.cache

--- a/docker/8.5/Dockerfile
+++ b/docker/8.5/Dockerfile
@@ -1,0 +1,33 @@
+FROM php:8.5-rc-alpine AS builder
+
+RUN apk add --no-cache \
+    git \
+    unzip \
+    $PHPIZE_DEPS
+
+RUN git config --global --add safe.directory /app
+
+WORKDIR /app
+
+FROM builder AS composer
+
+RUN curl -sS https://getcomposer.org/installer | php -- \
+    --install-dir=/usr/local/bin \
+    --filename=composer
+
+FROM builder AS debug
+
+RUN apk add --no-cache --virtual .build-deps \
+    $PHPIZE_DEPS \
+    linux-headers \
+  && pecl channel-update pecl.php.net \
+  && pecl install xdebug \
+  && docker-php-ext-enable xdebug \
+  && apk del .build-deps \
+  && rm -rf /tmp/* /var/cache/apk/*
+
+FROM php:8.5-rc-alpine AS base
+
+WORKDIR /app
+
+CMD ["bash"]

--- a/docker/8.5/php.ini
+++ b/docker/8.5/php.ini
@@ -1,0 +1,5 @@
+zend_extension = xdebug.so
+xdebug.mode = debug
+xdebug.start_with_request = yes
+xdebug.client_host = host.docker.internal
+xdebug.client_port = 9003

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-PHP_VERSIONS=("8.4" "8.3" "8.2" "8.1")
+PHP_VERSIONS=("8.5" "8.4" "8.3" "8.2" "8.1")
 
 for PHP_VERSION in "${PHP_VERSIONS[@]}"; do
 


### PR DESCRIPTION
## Description

This pull request introduces support for PHP 8.5 and includes the following changes:

- Updated the PHP version matrix to incorporate PHP 8.5.
- Added a `bin/zero-to-prod-omdb` script to facilitate documentation publishing.
- Modified `composer.json` to enable automatic documentation publishing.
- Set up Docker environment for PHP 8.5, including Xdebug.
- Upgraded GitHub Actions configuration to use `actions/checkout@v5`.

These updates ensure compatibility with the latest PHP version and improve the documentation workflows.